### PR TITLE
Wildcard support for csv filter

### DIFF
--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -51,10 +51,9 @@ boolean = (value) ->
 
 
 integer = (number, opt={}) ->
-  opt.default = 0 if opt.default == undefined || opt.default == null
-  return opt.default unless number = parseInt(number)
-  number = Math.min(number, opt.max) if opt.max != undefined
-  number = Math.max(number, opt.min) if opt.min != undefined
+  return opt.default || 0 unless number = Math.round(number)
+  number = Math.min(number, opt.max) if opt.max?
+  number = Math.max(number, opt.min) if opt.min?
   number
 
 
@@ -73,7 +72,7 @@ date = (string) ->
 dateRegex = "([0-9\.]{11,13}|[0-9]{4}-[0-9]{2}-[0-9a-zA-Z:\.]*)"
 dateRangeRegex = "#{dateRegex}?-?#{dateRegex}?"
 dateRange = (string, formatter=date) ->
-  string = String(string) if typeof string is 'number'
+  string = string.toString() if typeof string is 'number'
   if typeof string is 'string' && string = string?.match(new RegExp(dateRangeRegex))
     date1 = formatter(string[1])
     date2 = formatter(string[2])

--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -21,15 +21,28 @@ sort = (string, opt={}) ->
 
 
 csv = (string, opt={}) ->
-  opt.default ||= []
-  string = String(string) if typeof string is 'number'
-  return opt.default unless typeof string is 'string'
+  string = string.toString() if typeof string is 'number'
+  return opt.default || [] unless typeof string is 'string'
   if opt.allowed?.length
-    fields = intersection(opt.allowed, string.split(','))
+    all = string.split(',')
+    allowed = opt.allowed.reduce (res, field) ->
+      if prefix = field.match(/(.*\.)\*$/)
+        res.wildcards.push(prefix[1])
+      else
+        res.fields.push(field)
+
+      res
+    , {fields: [], wildcards: []}
+
+    fields = intersection(allowed.fields, all)
+    for wildcard in allowed.wildcards
+      fields = fields.concat(all.filter (val) -> val.indexOf(wildcard) == 0)
+
   else
     fields = string.split(',')
+
   return fields if fields?.length
-  return opt.default
+  return opt.default || []
 
 
 boolean = (value) ->

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -43,26 +43,45 @@ sort = function(string, opt) {
 };
 
 csv = function(string, opt) {
-  var fields, _ref;
+  var all, allowed, fields, wildcard, _i, _len, _ref, _ref1;
   if (opt == null) {
     opt = {};
   }
-  opt["default"] || (opt["default"] = []);
   if (typeof string === 'number') {
-    string = String(string);
+    string = string.toString();
   }
   if (typeof string !== 'string') {
-    return opt["default"];
+    return opt["default"] || [];
   }
   if ((_ref = opt.allowed) != null ? _ref.length : void 0) {
-    fields = intersection(opt.allowed, string.split(','));
+    all = string.split(',');
+    allowed = opt.allowed.reduce(function(res, field) {
+      var prefix;
+      if (prefix = field.match(/(.*\.)\*$/)) {
+        res.wildcards.push(prefix[1]);
+      } else {
+        res.fields.push(field);
+      }
+      return res;
+    }, {
+      fields: [],
+      wildcards: []
+    });
+    fields = intersection(allowed.fields, all);
+    _ref1 = allowed.wildcards;
+    for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
+      wildcard = _ref1[_i];
+      fields = fields.concat(all.filter(function(val) {
+        return val.indexOf(wildcard) === 0;
+      }));
+    }
   } else {
     fields = string.split(',');
   }
   if (fields != null ? fields.length : void 0) {
     return fields;
   }
-  return opt["default"];
+  return opt["default"] || [];
 };
 
 boolean = function(value) {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -95,16 +95,13 @@ integer = function(number, opt) {
   if (opt == null) {
     opt = {};
   }
-  if (opt["default"] === void 0 || opt["default"] === null) {
-    opt["default"] = 0;
+  if (!(number = Math.round(number))) {
+    return opt["default"] || 0;
   }
-  if (!(number = parseInt(number))) {
-    return opt["default"];
-  }
-  if (opt.max !== void 0) {
+  if (opt.max != null) {
     number = Math.min(number, opt.max);
   }
-  if (opt.min !== void 0) {
+  if (opt.min != null) {
     number = Math.max(number, opt.min);
   }
   return number;
@@ -142,7 +139,7 @@ dateRange = function(string, formatter) {
     formatter = date;
   }
   if (typeof string === 'number') {
-    string = String(string);
+    string = string.toString();
   }
   if (typeof string === 'string' && (string = string != null ? string.match(new RegExp(dateRangeRegex)) : void 0)) {
     date1 = formatter(string[1]);

--- a/test/unit/csv.coffee
+++ b/test/unit/csv.coffee
@@ -35,3 +35,13 @@ describe 'csv()', ->
 
     result = csv('notAllowed', default: ['foo'], allowed: ['foo', 'foo.bar'])
     expect(result[0]).to.be.equal('foo')
+
+
+  it 'Accepts wildcards in allowed array', ->
+    result = csv('foo.bar', allowed: ['foo', 'foo.*'])
+    expect(result).to.deep.equal(['foo.bar'])
+
+
+  it 'Accepts multiple wildcards in allowed array', ->
+    result = csv('foo.bar,bla.test,bla.*,bla', allowed: ['foo', 'foo.*', 'bla.*'])
+    expect(result).to.deep.equal(['foo.bar', 'bla.test', 'bla.*'])

--- a/test/unit/integer.coffee
+++ b/test/unit/integer.coffee
@@ -5,7 +5,7 @@ describe 'integer()', ->
   it 'returns a number', ->
     values = [null, undefined, 123, 'foo', {}, []]
     for value in values
-      expect(integer(value)).to.be.a('number')
+      expect(integer(value), "integer('#{value}')").to.be.a('number')
 
   it 'allows a default value', ->
     defaults = [100, -100, [], ->]


### PR DESCRIPTION
```js
parse.csv('notallowed,foo.bar,foo.bla', {allowed: ['foo', 'foo.*']})
// ['foo.bar', 'foo.bla']
```